### PR TITLE
fix(rocketact-scripts): fix css-loader support css-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",
-    "prettier": "^1.14.3",
+    "prettier": "^2.0.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-router-dom": "^4.3.1",

--- a/packages/rocketact-scripts/package.json
+++ b/packages/rocketact-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocketact-scripts",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/rocketact-scripts/package.json
+++ b/packages/rocketact-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocketact-scripts",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/rocketact-scripts/src/config/webpack/module.ts
+++ b/packages/rocketact-scripts/src/config/webpack/module.ts
@@ -68,7 +68,7 @@ export default (api: CoreAPI) => {
       // support css-module
       webpackChain.module
         .rule("scss-module")
-        .test(/module\.(css|sass|scss)$/)
+        .test(/\.module\.(css|sass|scss)$/)
         .use("style")
         .loader(require.resolve("style-loader"))
         .options({
@@ -115,7 +115,7 @@ export default (api: CoreAPI) => {
       // support css-module
       webpackChain.module
         .rule("scss-module")
-        .test(/module\.(css|sass|scss)$/)
+        .test(/\.module\.(css|sass|scss)$/)
         .use("mini-css-extract-plugin")
         .loader(MiniCssExtractPlugin.loader)
         .end()

--- a/packages/rocketact-scripts/src/config/webpack/module.ts
+++ b/packages/rocketact-scripts/src/config/webpack/module.ts
@@ -9,14 +9,14 @@ import { isDevelopmentEnv, isProductionEnv } from "../../utils/environment";
 import { getValidEntries, appRoot, appSrc } from "rocketact-dev-utils";
 
 export default (api: CoreAPI) => {
-  api.chainWebpack(webpackChain => {
+  api.chainWebpack((webpackChain) => {
     webpackChain.module
       .rule("font")
       .test(/\.(ttf|eot|woff|woff2)$/)
       .use("file")
       .loader(require.resolve("file-loader"))
       .options({
-        name: "css/fonts/[name].[ext]"
+        name: "css/fonts/[name].[ext]",
       })
       .end()
       .end()
@@ -27,7 +27,7 @@ export default (api: CoreAPI) => {
       .use("babel")
       .loader(require.resolve("babel-loader"))
       .options({
-        presets: [require.resolve("babel-preset-rocketact")]
+        presets: [require.resolve("babel-preset-rocketact")],
       })
       .end()
       .end()
@@ -36,24 +36,23 @@ export default (api: CoreAPI) => {
     if (isDevelopmentEnv()) {
       webpackChain.module
         .rule("scss")
-        .test(/\.(css|sass|scss)$/)
+        .test(/(?<!module)\.(css|sass|scss)$/) // extract css-module
         .use("style")
         .loader(require.resolve("style-loader"))
         .options({
-          sourceMap: true // FIXME: suport setting from --option
+          sourceMap: true, // FIXME: suport setting from --option
         })
         .end()
         .use("css")
         .loader(require.resolve("css-loader"))
         .options({
           sourceMap: true, // FIXME: suport setting from --option
-          modules: true
         })
         .end()
         .use("postcss")
         .loader(require.resolve("postcss-loader"))
         .options({
-          sourceMap: true // FIXME: suport setting from --option
+          sourceMap: true, // FIXME: suport setting from --option
         })
         .end()
         .use("scss")
@@ -61,31 +60,68 @@ export default (api: CoreAPI) => {
         .options({
           sourceMap: true, // FIXME: suport setting from --option
           outputStyle: "compressed",
-          implementation: require("node-sass")
+          implementation: require("node-sass"),
         })
         .end()
+        .end();
+
+      // support css-module
+      webpackChain.module
+        .rule("scss-module")
+        .test(/module\.(css|sass|scss)$/)
+        .use("style")
+        .loader(require.resolve("style-loader"))
+        .options({
+          sourceMap: true, // FIXME: suport setting from --option
+        })
         .end()
+        .use("css")
+        .loader(require.resolve("css-loader"))
+        .options({
+          sourceMap: true, // FIXME: suport setting from --option
+          modules: true,
+          // modules: new RegExp(/(module)\.(css|sass|scss)$/).test(webpackChain.module.)
+        })
+        .end()
+        .use("postcss")
+        .loader(require.resolve("postcss-loader"))
+        .options({
+          sourceMap: true, // FIXME: suport setting from --option
+        })
+        .end()
+        .use("scss")
+        .loader(require.resolve("sass-loader"))
+        .options({
+          sourceMap: true, // FIXME: suport setting from --option
+          outputStyle: "compressed",
+          implementation: require("node-sass"),
+        })
+        .end()
+        .end();
+
+      webpackChain.module
         .rule("image")
         .test(/\.(png|jpg|gif|svg|jpeg|webp)$/)
         .use("file")
         .loader(require.resolve("file-loader"))
         .options({
           name: "css/i/[name].[hash:8].[ext]",
-          publicPath: "/"
+          publicPath: "/",
         })
         .end();
     }
 
     if (isProductionEnv()) {
+      // support css-module
       webpackChain.module
-        .rule("scss")
-        .test(/\.(css|sass|scss)$/)
+        .rule("scss-module")
+        .test(/module\.(css|sass|scss)$/)
         .use("mini-css-extract-plugin")
         .loader(MiniCssExtractPlugin.loader)
         .end()
         .use("css")
         .loader(require.resolve("css-loader"))
-        .options({modules: true})
+        .options({ modules: true })
         .end()
         .use("postcss")
         .loader(require.resolve("postcss-loader"))
@@ -93,7 +129,27 @@ export default (api: CoreAPI) => {
         .use("scss")
         .loader(require.resolve("sass-loader"))
         .options({
-          implementation: require("node-sass")
+          implementation: require("node-sass"),
+        })
+        .end()
+        .end();
+
+      webpackChain.module
+        .rule("scss")
+        .test(/(?<!module)\.(css|sass|scss)$/) // extract css-module
+        .use("mini-css-extract-plugin")
+        .loader(MiniCssExtractPlugin.loader)
+        .end()
+        .use("css")
+        .loader(require.resolve("css-loader"))
+        .end()
+        .use("postcss")
+        .loader(require.resolve("postcss-loader"))
+        .end()
+        .use("scss")
+        .loader(require.resolve("sass-loader"))
+        .options({
+          implementation: require("node-sass"),
         })
         .end()
         .end();
@@ -104,7 +160,7 @@ export default (api: CoreAPI) => {
         .use("html")
         .loader(require.resolve("html-loader"))
         .options({
-          attrs: ["img:src"]
+          attrs: ["img:src"],
         })
         .end()
         .end()
@@ -114,7 +170,7 @@ export default (api: CoreAPI) => {
         .loader(require.resolve("url-loader"))
         .options({
           limit: 10 * 1024,
-          name: "img/[name].[hash:8].[ext]"
+          name: "img/[name].[hash:8].[ext]",
         })
         .end();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3889,7 +3889,7 @@ css-declaration-sorter@^4.0.1:
     postcss "^7.0.1"
     timsort "^0.3.0"
 
-css-loader@^2.0.1, css-loader@^2.1.0:
+css-loader@2.1.0, css-loader@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-2.1.0.tgz#42952ac22bca5d076978638e9813abce49b8f0cc"
   integrity sha512-MoOu+CStsGrSt5K2OeZ89q3Snf+IkxRfAIt9aAKg4piioTrhtP1iEFPu+OVn3Ohz24FO6L+rw9UJxBILiSBw5Q==
@@ -9824,6 +9824,11 @@ prettier@^1.14.3:
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
   integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+
+prettier@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
fix #58 

上次提交支持css-modules的问题引起一个新问题，css-loader v2.1.0 不能自动识别 css-modules 模块，导致现有的 css 无法编译，升级 v4 短期成本比较高，采用这种这种的方式，把默认的 `*.modules.css` 这种形式的文件增加 modules: true，其他非 *.module 文件按照原有规则编译。

同时升级本地工程的 prettier 版本。

本次变更，请关注，module.ts L66~L136